### PR TITLE
Add data about android devices

### DIFF
--- a/android-devices/README.md
+++ b/android-devices/README.md
@@ -1,0 +1,7 @@
+# Android devices running NZ COVID Tracer
+
+This is a report of the NZ COVID Tracer install base according to the Google Play console. It shows the number of unique devices of each type that have installed NZ COVID Tracer and have been on in the last thirty days.
+
+As one of the most widely installed apps in New Zealand, this information may be of interest to other app developers.
+
+This data was last updated in January 2021.

--- a/android-devices/android-devices.csv
+++ b/android-devices/android-devices.csv
@@ -1,0 +1,502 @@
+Device name,Number of active devices
+All devices,1139139
+Samsung Galaxy A10 (a10),52820
+Samsung Galaxy S9 (starlte),45682
+Samsung Galaxy S8 (dreamlte),41443
+Samsung Galaxy S10 (beyond1),38634
+Samsung Galaxy S10+ (beyond2),33315
+Samsung Galaxy S7  (herolte),31419
+Samsung Galaxy S9+ (star2lte),28399
+Huawei nova 3i (HWINE),23323
+Samsung Galaxy A50 (a50),23192
+Samsung Galaxy Note9 (crownlte),23141
+Samsung Galaxy A51 (a51),22394
+Samsung Galaxy A30 (a30),21708
+Samsung Galaxy Note10+ (d2s),18117
+Samsung Galaxy A31 (a31),17120
+Huawei P30 Pro (HWVOG),16305
+Samsung Galaxy A11 (a11q),15727
+Samsung Galaxy A8(2018) (jackpotlte),15690
+Samsung Galaxy S20 5G (x1s),15521
+Samsung Galaxy S8+ (dream2lte),14987
+Samsung Galaxy Note8 (greatlte),14738
+Samsung Galaxy S20 Ultra 5G (z3s),14357
+Samsung Galaxy A20 (a20),14122
+Samsung Galaxy S20+ 5G (y2s),12809
+Samsung Galaxy S10e (beyond0),12515
+Samsung Galaxy J5 Prime (on5xelte),12258
+Samsung Galaxy A70 (a70q),12249
+Samsung Galaxy J2 (j2y18lte),12204
+Samsung Galaxy S7 edge (hero2lte),12162
+Samsung Galaxy J5 Pro (j5y17ltedx),11101
+Oppo A9 2020 (OP4B80L1),10987
+Oppo A5 2020 (OP4B79L1),10536
+Samsung Galaxy Note20 Ultra (c2s),10522
+Samsung Galaxy A21s (a21s),10483
+Huawei HUAWEI Y5 2019 (HWAMN-M),10218
+Samsung Galaxy J3 Pro (j3y17lte),9808
+Samsung Galaxy A5(2017) (a5y17lte),9461
+Samsung Galaxy S6 (zeroflte),9449
+Oppo CPH1903 (CPH1903),9112
+Huawei HUAWEI nova 5T (HWYAL),9086
+Huawei HUAWEI P30 (HWELE),8926
+Samsung Galaxy XCover4 (xcover4lte),8611
+Huawei Y9 Prime 2019 (HWSTK-HF),8202
+Samsung Galaxy J4 (j4lte),7869
+Huawei P20 Pro (HWCLT),7365
+Huawei HUAWEI P20 Lite (HWANE),7364
+Samsung Galaxy S20 FE (r8s),7257
+Samsung Galaxy J4+ (j4primelte),7127
+Samsung Galaxy A01 (a01q),6890
+Oppo CPH1851 (CPH1851),6633
+Samsung Galaxy J6 (j6lte),6133
+Samsung Galaxy S5  (klte),5888
+Samsung Galaxy XCover 4s (xcover4s),5684
+Huawei Mate 10 lite (HWRNE),5651
+Huawei Mate 20 RS (HWLYA),5499
+Samsung Galaxy J6+ (j6primelte),5336
+Samsung Galaxy A71 (a71),5276
+Samsung Galaxy J8 (j8y18lte),5055
+OP4B9B,4776
+Samsung Galaxy A8+(2018) (jackpot2lte),4547
+Samsung Galaxy Note10 (d1),4364
+Oppo CPH1725 (CPH1725),4282
+Huawei P20 (HWEML),4183
+Samsung Galaxy Note20 (c1s),3984
+Oppo A72 (OP4C72L1),3652
+Huawei HUAWEI Y6 Prime 2018 (HWATU-QG),3217
+Oppo Find X2 Lite (OP4C41L1),3197
+Samsung Galaxy J7 Pro (j7y17lte),3024
+Oppo AX5s (CPH1920),3008
+Huawei 华为畅享8 (HWLDN-Q),2834
+Samsung Galaxy A7(2017) (a7y17lte),2735
+Huawei P10 lite (HWWAS-H),2655
+Vodafone Smart V8 (VFD710),2563
+Samsung Galaxy Note5 (noblelte),2554
+Redmi Redmi  Note  7 (lavender),2492
+Samsung Galaxy A3(2017) (a3y17lte),2466
+Vodafone Smart_N9_Lite (VFD620),2443
+TCT (Alcatel) Alcatel 1S (Tokyo),2418
+Samsung Galaxy J7 Prime (on7xelte),2411
+Oppo Reno2 Z (OP4B65L1),2399
+Nokia Nokia 6.1 (PL2_sprout),2389
+Nokia Nokia 7 plus (B2N_sprout),2377
+Samsung Galaxy A90 5G (r3q),2340
+Huawei HUAWEI Y6 Pro 2019 (HWMRD-M1),2313
+OnePlus OnePlus 6 (OnePlus6),2262
+Samsung Galaxy A5(2016) (a5xelte),2237
+Oppo R15 Pro (CPH1831),2199
+Samsung Galaxy A3(2016) (a3xelte),2113
+OnePlus OnePlus6T (OnePlus6T),2030
+Oppo CPH1723 (CPH1723),2003
+Samsung Galaxy S6 edge (zerolte),1994
+Huawei P10 (HWVTR),1955
+Oppo Reno Z (OP48A1),1931
+Oppo A52 (OP4C7BL1),1804
+OnePlus OnePlus5T (OnePlus5T),1779
+OnePlus OnePlus 7 Pro (OnePlus7Pro),1742
+Vodafone Smart N8 (VFD610),1693
+Huawei P9 (HWEVA),1689
+Samsung Galaxy A01 Core (a01core),1669
+Huawei Mate 10 (HWALP),1610
+Huawei Honor 8 Smart (HWVNS-H),1600
+Oppo CPH1719 (CPH1719),1599
+Vodafone Vodafone Smart E9 (VFD529),1541
+Samsung Galaxy A80 (r1q),1482
+Nokia Nokia 6 (PLE),1421
+Samsung Galaxy A Quantum (a71x),1343
+Huawei Mate 10 Pro (HWBLA),1329
+Redmi Redmi Note 9 Pro (curtana),1325
+Oppo Find X2 Pro (OP4BA2L1),1315
+Oppo R17 Pro (CPH1877),1311
+Xiaomi POCO F1 (beryllium),1282
+Vodafone Vodafone Smart N9 (VFD720),1268
+Samsung Galaxy Note10+ 5G (d2x),1268
+Oppo Reno 2 (OP4B83L1),1250
+Samsung Galaxy J5 (j5ylte),1243
+Huawei Mate 20 (HWHMA),1210
+Samsung Galaxy Note4 (trhplte),1208
+Redmi Redmi Note 8 Pro (begonia),1203
+Google Pixel 3 (blueline),1203
+Huawei Honor 8A (HWJAT-M),1189
+Huawei nova 3 (HWPAR),1169
+ZTE Vodafone Smart X9 (VFD822),1167
+Samsung Galaxy S10 (beyond1q),1135
+Nokia Nokia 5 (ND1),1130
+Samsung Galaxy J2 Core (j2corelte),1124
+Huawei P9 Plus (HWVIE),1115
+Samsung Galaxy S9 (starqltesq),1111
+Google Pixel 3a (sargo),1110
+Huawei Mate 9 (HWMHA),1104
+Huawei HUAWEI Y7 Pro 2019 (HWDUB-Q),1101
+Redmi Redmi Note 9 Pro (joyeuse),1098
+Google Pixel 2 (walleye),1089
+Vodafone Vodafone Smart N10 (VFD630),1077
+Samsung Galaxy Z Flip (bloomq),1076
+Mobiwire Smart N11 (Smart_N11),1059
+Xiaomi Redmi Note 5 (whyred),1037
+Samsung Galaxy S9 (starqlteue),1019
+Samsung Galaxy S7 (heroqlteue),1010
+Samsung Galaxy Grand Prime Plus (grandpplte),1005
+Motorola Moto G (5S) (montana_n),998
+Nokia Nokia 5.1 (CO2_sprout),997
+OnePlus OnePlus3T (OnePlus3T),996
+Nokia Nokia 3 (NE1),994
+OnePlus OnePlus5 (OnePlus5),990
+Nokia Nokia 2.3 (IRM_sprout),987
+Samsung Galaxy S10e (beyond0q),986
+Oppo CPH1707 (CPH1707),977
+Redmi Redmi 8 (olive),957
+Spark Spark_Plus_3 (Spark_Plus_3),954
+Huawei P10 Plus (HWVKY),952
+Huawei GT3 (HWNMO-H),942
+Samsung Galaxy S6 Edge+ (zenlte),930
+Oppo CPH1701 (CPH1701),929
+Samsung Galaxy S8 (dreamqlteue),908
+TCT (Alcatel) Alcatel 1 (U3A_PLUS_4G),899
+Samsung Galaxy S8 (dreamqltesq),878
+Google Pixel 2 XL (taimen),872
+Huawei 荣耀畅享7 Plus (HWTRT-Q),851
+Oppo Reno 10x Zoom (OP4845),849
+Oppo R15 (CPH1835),846
+Xiaomi Mi A3 (laurel_sprout),827
+Samsung Galaxy S5 mini (kminilte),826
+Nokia Nokia 8 (NB1),825
+Redmi Redmi K20 (davinci),823
+Xiaomi Mi A1 (tissot_sprout),809
+OnePlus OnePlus 7T (OnePlus7T),803
+Nokia Nokia 1 (FRT),796
+Nokia Nokia 7.1 (CTL_sprout),787
+Nokia Nokia 3.1 (ES2_sprout),771
+Vodafone Vodafone Smart E8 (VFD513),768
+Huawei Y6 2017 (HWMYA-L6737),764
+Nokia Nokia 7.2 (DDV_sprout),751
+Samsung Galaxy Z Fold2 5G (f2q),744
+LGE LG G6 (lucye),737
+Motorola Moto G (5S) Plus (sanders_n),737
+LGE LG G7 ThinQ (judyln),734
+Nokia Nokia 4.2 (PAN_sprout),718
+Nokia Nokia 1.3 (DRX),714
+Samsung Galaxy S10+ (beyond2q),714
+ZTE BLADE A310 (P809A50),710
+Google Pixel 3 XL (crosshatch),706
+Cat Cat S61 (CatS61),695
+Redmi Redmi K20 Pro (raphael),692
+HWLIO,689
+Vodafone Smart ultra 7 (VFD700),683
+Nokia Nokia 2.1 (E2M),656
+Samsung Galaxy Tab A (gta3xlwifi),653
+Xiaomi MI 9 (cepheus),652
+OnePlus OnePlus 8 Pro (OnePlus8Pro),645
+Redmi Redmi Note 8 (ginkgo),643
+Xiaomi  Redmi Note 4 (mido),627
+LGE V30 (joan),615
+Oppo CPH1715 (CPH1715),599
+Redmi Redmi Note 9 (merlin),598
+Samsung Galaxy A7 (2018) (a7y18lte),595
+Xiaomi Mi A2 (jasmine_sprout),595
+Huawei HUAWEI P30 lite (HWMAR),593
+Google Pixel 4a (sunfish),593
+TCT (Alcatel) Alcatel 1V (Wright),592
+Motorola moto g(7) power (ocean_n),580
+Xiaomi MI 8 Lite (platina),578
+Samsung Galaxy S9+ (star2qlteue),578
+Samsung Galaxy A3 (a3ulte),571
+ZTE ZTE BLADE A330 (P809F30),569
+Samsung Galaxy A30s (a30s),563
+TCT (Alcatel)  Alcatel 1S  (Faraday),546
+Samsung Galaxy S7 (heroqltevzw),541
+Nokia Nokia 2 (E1M),539
+Vodafone Smart ultra 6 (P839V55),529
+Samsung Galaxy A5 (a5ulte),523
+Sony Xperia XA (F3115),521
+Redmi Redmi 8A (olivelite),515
+Motorola Moto G (5) Plus (potter_n),512
+T-Mobile REVVLRY+ (lake_n),509
+Motorola moto g fast (rav),508
+OnePlus OnePlus Nord (Nord),496
+Redmi K30 PRO (lmi),491
+Oppo Reno4 5G (OP4C45L1),489
+Sony Xperia XA1 (G3125),488
+Samsung Galaxy S9+ (star2qltesq),487
+Vodafone Vodafone Smart V10 (VFD730),486
+Oppo R9s (CPH1607),481
+Samsung Galaxy Tab S6 Lite (gta4xlwifi),480
+Motorola moto g(7) (river_n),467
+Xiaomi Mi A2 Lite (daisy_sprout),465
+Motorola moto g(6) plus (evert_n),464
+Motorola moto g(6) play (aljeter),456
+OnePlus OnePlus 7 (OnePlus7),454
+Samsung Galaxy Tab A (2016) (gtaxlwifi),448
+Blackshark Shark 1S  (bullhead),439
+Google Pixel XL (marlin),438
+Motorola moto g(6) (ali_n),419
+Meizu M6 Note (M6Note),410
+Motorola Moto E (5) (nora_8917),408
+Samsung Galaxy A20s (a20s),402
+Samsung Galaxy Xcover3 (xcover3velte),402
+Sony Xperia XZ (F8331),400
+POCO POCO X3 NFC (surya),400
+OnePlus OnePlus3 (OnePlus3),395
+OnePlus OnePlus 8 (OnePlus8),393
+ZTE BLADE V7 (P653A10),393
+Coolpad 1904 (1904),392
+Vodafone VFD320 (VFD320),390
+HWELS,380
+Xiaomi MI CC9 Pro (tucana),379
+Google Pixel (sailfish),368
+Xiaomi Redmi  Note  6  Pro (tulip),368
+Samsung Galaxy S8+ (dream2qlteue),365
+Nokia Nokia 9 (AOP_sprout),353
+Samsung Galaxy J5 Pro (j5y17lte),352
+Sony Xperia XZ Premium (G8141),349
+Samsung Galaxy M01s (a10s),347
+Samsung Galaxy S9 (starqltechn),342
+Samsung Galaxy S7 Active (poseidonlteatt),341
+Google Pixel 4 (flame),334
+Samsung Galaxy S8 (dreamqltechn),333
+Samsung Galaxy Note8 (greatlteks),333
+Xiaomi Redmi  Note  7 Pro (violet),333
+Google Pixel 4 XL (coral),330
+Huawei nova lite (HWPRA-H),326
+Motorola Moto G(4) Plus (athene_f),326
+Samsung Galaxy A50s (a50s),324
+Samsung Galaxy Note9 (crownqlteue),323
+Xiaomi MI 9 SE (grus),321
+Xiaomi Redmi S2 (ysl),321
+Samsung Galaxy Note8 (greatqltechn),318
+Motorola Moto G (5th Gen) (cedric),314
+Xiaomi Redmi 5 Plus (vince),310
+Samsung Galaxy Note9 (crownlteks),308
+Samsung Galaxy Tab A Kids Edition (gtowifi),304
+Samsung Galaxy XCover Pro (xcoverpro),300
+Redmi Redmi Note 8T (willow),289
+Xiaomi MI 8 (dipper),287
+Oppo Find X (CPH1875),278
+LGE V20 (elsa),278
+Samsung Galaxy Tab A (2018 10.5) (gta2xlwifi),278
+Samsung Galaxy S9+ (star2lteks),277
+Vodafone Smart turbo 7 (VFD501),275
+Samsung Galaxy S9+ (star2qltechn),271
+Cat Cat S41 (CatS41),268
+Bullitt Group Cat S60 (CatS60),268
+Samsung Galaxy Note10+ (d2q),268
+Samsung Galaxy S8+ (dream2qltesq),268
+Samsung Galaxy S8 Active (cruiserlteatt),267
+Google Pixel 5 (redfin),264
+Huawei Huawei Mate 20 X (HWEVR),261
+TCT (Alcatel) Alcatel 1X (U5A_PLUS_4G),260
+TCT (Alcatel) Alcatel 3 (A3A),257
+Google Pixel 3a XL (bonito),256
+Xiaomi Mi 9 Lite (pyxis),251
+Samsung Galaxy M31 (m31),250
+Nokia Nokia 6.1 Plus (DRG_sprout),248
+Huawei Mate 9 Pro (HWLON),248
+Motorola moto g(8) plus (doha_n),248
+Xiaomi Redmi 7 (onc),244
+Sony Xperia Z5 Compact (E5823),243
+Samsung Galaxy Tab A 8.0 (gt58wifi),242
+Nokia Nokia 2.2 (WSP_sprout),240
+Samsung Galaxy Note9 (crownqltechn),239
+Samsung Galaxy Tab A (8.0 2019) (gto),235
+Meizu M6s (MeizuM6s),234
+Motorola moto g(8) power lite (blackjack),233
+Samsung Galaxy S8 (dreamlteks),233
+Samsung Galaxy Tab A 8.0 (gt58lte),233
+Samsung Galaxy S8+ (dream2qltechn),223
+Xiaomi Redmi 4X (santoni),223
+Sony Xperia XZ2 (H8216),221
+Samsung Galaxy Tab A (gta3xl),217
+Sony Xperia XZ1 (G8341),216
+Huawei Honor 10 (HWCOL),214
+Vivo vivo 1907 (1907),213
+Sony Xperia XZ2 Compact (H8314),211
+Samsung Galaxy A40 (a40),210
+Samsung Galaxy Tab Active2 (gtactive2lte),209
+Oppo F9 (CPH1823),208
+Sony Xperia X (F5121),206
+OnePlus OnePlus 7T Pro (OnePlus7TPro),204
+Huawei Nexus 6P (angler),203
+Samsung Galaxy S9 (starlteks),201
+Samsung Galaxy S7 edge (hero2qlteue),199
+Redmi Redmi Note 8 pro (begoniain),198
+Motorola motorola one vision (kane_sprout),195
+Oppo A53 (OP4EFDL1),194
+Samsung Galaxy A9 (2018) (a9y18qlte),194
+Samsung Galaxy J7(2016) (j7xelte),192
+Huawei 华为畅享7S (HWFIG-H),191
+Samsung Galaxy M51 (m51),191
+Nokia Nokia 1 Plus (ANT),190
+Samsung Galaxy S7 edge (hero2qltechn),188
+Xiaomi MI MAX 3 (nitrogen),187
+Xiaomi MI MAX 2 (oxygen),187
+Samsung Galaxy Note10 Lite (r7),187
+Xiaomi MIX 2S (polaris),185
+Asus ROG Phone 3 (ASUS_I003_1),184
+HWANA,183
+Huawei Mate 8 (HWNXT),181
+Samsung Galaxy A6+ (a6plte),181
+Samsung Galaxy J5(2016) (j5xnlte),181
+Samsung Galaxy S10 5G (beyondx),178
+Motorola Moto C (namath),178
+Samsung Galaxy S7  (heroqltetmo),177
+Samsung Galaxy S8+ (dream2lteks),171
+Samsung Galaxy Fold (winner),171
+Asus ZenFone 3 (ZE552KL) (ASUS_Z012D),170
+Sony Xperia XZ Premium (G8142),167
+Samsung Galaxy Note9 (crownqltesq),166
+Huawei HUAWEI Y9 2019 (HWJKM-H),164
+Motorola moto g(7) power (ocean),164
+Samsung Galaxy A6 (a6lte),163
+Redmi Redmi 6 (cereus),163
+Xiaomi MIX 2 (chiron),162
+Samsung Galaxy Tab A (2017) (gta2swifi),161
+Huawei 荣耀 8X (HWJSN-H),160
+Samsung Galaxy M30s (m30s),160
+Xiaomi MI6 (sagit),160
+Samsung Galaxy Note8 (greatqlte),159
+Sony Xperia XZ1 Compact (G8441),158
+Xiaomi MIX 3 (perseus),158
+TCT (Alcatel) ALCATEL ONETOUCH PIXI 4 (4) (Pixi4-4),157
+Motorola Moto G4 Play (harpia),155
+Samsung Galaxy Z Flip 5G (bloomxq),154
+Sony Xperia X Compact (F5321),153
+Huawei Honor 7X (HWBND-H),153
+Oppo Reno4 Pro 5G (OP4C87L1),152
+TCT (Alcatel) Alcatel 1B (Seoul),152
+ZTE N9101 (apollo),152
+LGE V40 ThinQ (judypn),152
+Samsung Galaxy Note8 (greatqlteue),151
+Blackview BV8000 Pro (BV8000Pro),150
+LGE Nexus 5 (hammerhead),147
+Samsung Galaxy Tab A (2017) (gta2slte),146
+Motorola Moto E (4) (woods_f),145
+Samsung Galaxy J7 Neo (j7velte),144
+Huawei Honor 9 (HWSTF),142
+Sony Xperia XZ2 (H8296),141
+Samsung Galaxy S7  (heroltebmc),141
+Sony Xperia Z5 (E6653),140
+Xiaomi Redmi Note 4 (nikel),140
+Oppo Reno 4Z 5G (OP4BDCL1),139
+Lenovo Lenovo Tab M10 (HD) (TB-X505F),139
+Asus ROG Phone ll (ASUS_I001_1),138
+Sony Xperia XZ (F8332),138
+Huawei HUAWEI Mate 20 lite (HWSNE),137
+Samsung Galaxy A60 (a60q),137
+OnePlus OnePlus 8T (OnePlus8T),136
+Vodafone Smart mini 7 (VFD300),136
+Samsung Galaxy Tab A7 (gta4lwifi),136
+Xiaomi Redmi Note 3 (kate),136
+Samsung Galaxy Note10 (d1q),135
+TCT (Alcatel) SHINE LITE (shine_lite),135
+Oppo F7 (CPH1819),134
+Motorola Moto X (4) (payton),134
+M5Note,133
+OP4F2F,133
+Samsung Galaxy Tab S7+ (gts7xlwifi),133
+LGE LG Q6 (mh),132
+Motorola Moto G (2nd Gen) (titan_umtsds),132
+Samsung Galaxy Tab S2 (gts210vewifi),131
+Huawei 荣耀畅玩 6X (HWBLN-H),130
+M5c,130
+Huawei HUAWEI P smart+ 2019 (HWPOT-H),129
+Huawei 荣耀9青春版 (HWLLD-H),128
+Vivo Y17 (1902D),127
+Umidigi A5 Pro (A5_Pro),127
+Samsung Galaxy Tab S5e (gts4lvwifi),127
+HTC U11 (htc_ocndugl),127
+Motorola Moto G (3rd Gen) (osprey_ud2),127
+TCT (Alcatel) U5 (BUZZ6T4G),126
+Oppo A3s (CPH1803),126
+Samsung Galaxy S6 Active (marinelteatt),126
+Samsung Galaxy S7  (heroqlteatt),125
+Sony Xperia XA2 (H3133),124
+Samsung Galaxy C9 Pro (c9ltechn),124
+Xiaomi Redmi 6A (cactus),123
+Oppo F11 Pro (OP4863),120
+Samsung Galaxy J7 Prime (on7xltechn),119
+Samsung Galaxy S20+ 5G (y2q),119
+Sony Xperia XZ1 (G8342),118
+Samsung Galaxy S6 (zerofltevzw),117
+Huawei HONOR V20 (HWPCT),116
+Lenovo Lenovo Tab M10 FHD Plus (X606F),116
+Samsung Galaxy S8 Active (cruiserltesq),116
+Samsung Galaxy On Max (j7maxlte),116
+Everis E0114 (E0114),112
+Vivo V1937 (1937),111
+TCT (Alcatel) 9001D (Pixi4-6_4G),111
+Xiaomi Mi 5 (gemini),111
+Huawei Honor V10 (HWBKL),110
+Samsung Galaxy Tab S6 (gts6lwifi),110
+HTC U11 (htc_ocnuhl),110
+Samsung Galaxy S9 (starqltecs),110
+Xiaomi Mi Note 10 Lite (toco),110
+Samsung Galaxy Note4 (trlte),110
+Motorola moto g(6) (ali),109
+LGE LG G5 (h1),109
+Vivo vivo 1938 (1938),108
+Samsung Galaxy S20 5G (x1q),108
+Huawei nova 4 (HWVCE),107
+OnePlus 2 (OnePlus2),106
+Samsung Galaxy Tab S6 Lite (gta4xl),106
+Oppo F11 (OP4883),104
+Samsung Galaxy Tab A (2016) with S Pen (gtanotexllte),103
+Samsung Galaxy S20 FE 5G (r8q),103
+Samsung Galaxy S8 (dreamqltecan),102
+Motorola moto g(9) play (guamp),102
+Motorola Moto G Plus (5th Gen) (potter),102
+Oppo CPH1909 (CPH1909),100
+Sony Xperia XA2 (H4133),99
+Samsung Galaxy M20 (m20lte),99
+Asus ZenFone 4 (ZE554KL) (ASUS_Z01KDA),98
+Blackview BV9600Pro (Blackview),98
+Samsung Galaxy S6 (zerofltechn),97
+Lenovo Lenovo Tab M8  (8505F),96
+Samsung Galaxy A20e (a20e),96
+Motorola moto g(9) plus (odessa),96
+Samsung Galaxy S7  (herolteskt),95
+HTC One (M8) (htc_m8),95
+Xiaomi Redmi Go (tiare),95
+HP Slate 7 (pine),94
+Nokia Nokia 8.1 (PNX_sprout),93
+Vivo vivo 1723 (1723),91
+Huawei honor 10 Lite (HWHRY-H),91
+OnePlus OnePlus6T (OnePlus6TSingle),91
+Samsung Galaxy Tab A (gt5note10wifi),90
+Samsung Galaxy Tab S7 (gts7lwifi),90
+HTC M10 (htc_pmeuhl),90
+Xiaomi Redmi Note 5A (ugg),90
+Vivo vivo 1804 (1804),89
+TCT (Alcatel) ALCATEL 3C (A3A_XL_3G),86
+Blackview BV9800 (BV9800),86
+ZTE ZTE BLADE A521 (P809F10),86
+Samsung Galaxy Tab S2 (gts210wifi),86
+Samsung Galaxy Tab S3 (gts3lwifi),86
+TCT (Alcatel) Alcatel U3 (PIXI4-4C_GO),85
+LGE LG G4 (p1),85
+TCT (Alcatel) Alcatel 3V (A3A_XL_4G),83
+Blackview Blackview BV9700Pro (BV9700Pro),83
+Ulefone Armor_X5 (Armor_X5),82
+Motorola Moto Z (2) Play (albus),82
+Oppo CPH1609 (CPH1609),80
+Samsung Galaxy Tab A (2018 10.5) (gta2xllte),80
+Sony Xperia Z2 (D6503),79
+Samsung Galaxy A70s (a70s),79
+Samsung  Galaxy Tab S6  (gts6l),79
+Samsung Galaxy M30 (m30lte),79
+Sony Xperia 1 (J9110),78
+Huawei Honor 8 (HWFRD),77
+Huawei HONOR 10i (HWHRY-HF),77
+HWTAS,77
+LGE G8S ThinQ (betalm),77
+HTC One M9 (htc_himauhl),76
+Samsung Galaxy Note4 (trelte),76
+Vivo 1601 (1601),74
+LGE LG K10 LTE (m253),74
+LGE LG Q7 (mcv5a),74
+LGE QStylus (mcv7a),74
+Samsung Galaxy S20 Ultra 5G (z3q),73
+OnePlus One (A0001),72
+Nokia Nokia 5.3 (CAP_sprout),72
+Blackview BV9800Pro (BV9800Pro),71
+All other devices,95


### PR DESCRIPTION
This data has been exported from the Google Play Console and shows the distribution of Android devices that have installed NZ COVID Tracer. 